### PR TITLE
Test/add badge for mutation score

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # learning-python
 
+![badge-for-mutation-testing-score](./mutation-testing-score.svg)
+
 Project to explore Python's possibilities:
 
 ## Overview of the project and goals
@@ -65,6 +67,7 @@ For now, the tests are not parallelized.
 
 Needed improvements for a real use case:
 [ ] Parallelize the tests in an automated fashion (i.e. not having to start the servers manually)
+[ ] Make badge generation automatic so that the badge always reflects the latest score (instead of the score of the latest committed svg)
 
 #### Start the workers to parallelize the tests
 
@@ -114,3 +117,14 @@ Or if you want to keep the results / want a report that's a bit more readable:
 ```
 
 If you're done with the workers, you can kill the processes in the relevant terminal.
+
+#### Generate the badge
+
+There is currently no option to "fail" the mutation step like for test coverage.
+So, instead, what we can do is generate a badge to at least make it visible:
+
+```
+    uv run cr-badge pyproject.toml mutation-testing-score mutation-tests.sqlite
+```
+
+It does have some caveat in the current version though, we need to run the tests locally, generate the badge, and commit the svg, so a lot of manual steps are involved (and rely on a developper's good-will / remembering the steps)

--- a/mutation-score.svg
+++ b/mutation-score.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="126" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="anybadge_1">
+        <rect width="126" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#anybadge_1)">
+        <path fill="#555" d="M0 0h62v20H0z"/>
+        <path fill="#4C1" d="M62 0h64v20H62z"/>
+        <path fill="url(#b)" d="M0 0h126v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="32.0" y="15" fill="#010101" fill-opacity=".3">mutation</text>
+        <text x="31.0" y="14">mutation</text>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="95.0" y="15" fill="#010101" fill-opacity=".3">100.00 %</text>
+        <text x="94.0" y="14">100.00 %</text>
+    </g>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,13 @@ name = "http"
 
 [cosmic-ray.distributor.http]
 worker-urls = ["http://localhost:9800", "http://localhost:9801"]
+
+[cosmic-ray.badge]
+label = "mutation"
+format = "%.2f %%"
+
+[cosmic-ray.badge.thresholds]
+80  = 'red'
+90  = 'orange'
+95 = 'yellow'
+100 = 'green'


### PR DESCRIPTION
Since there is no config for setting a mutation threshold that would fail a step, similar to the coverage threshold (like in other similar tools like Stryker in JS), add a badge to at least have a visibility of the mutation score (with caveats, as per the README)